### PR TITLE
Add build setting to specify which type of lodash build to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,17 @@ gulp.task('lodash', function (cb) {
     })
 });
 ```
+
+## Options
+
+### target
+
+`String` - Where to output the custom build lodash file.
+
+### build
+
+`String` - Which custom lodash build to use. Build types: `compat`, `modern`, `strict`, `modularize`. See [Lodash Custom Builds](https://lodash.com/custom-builds) for details on build options.
+
+### settings
+
+`Object` - Sent to Lodash CLI as `settings` for precompiling templates. See [Lodash Custom Builds](https://lodash.com/custom-builds) for more details.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ var lodashBuilder = require('gulp-lodash-builder');
 
 var options = {
   target: "/assets/javascript/vendor/lodash.custom.js",
+  build: 'compat',
   settings: {}
 };
 gulp.task('lodash', function (cb) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ var pkg = require('lodash-cli/package.json'),
 var PLUGIN_NAME = 'gulp-lodash-builder';
 
 function gulpLodashRequire(options) {
-  var options = options ? options : {target: './lodash.custom.js', settings: {}, build: 'compat'};
+  var options = options ? {};
+  options.target = options.target ? './lodash.custom.js';
+  options.settings = options.settings ? {};
+  options.build = options.build ? 'compat';
+
   var dependiencies = [];
   var search = /_\.(\w*)/g;
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var pkg = require('lodash-cli/package.json'),
 var PLUGIN_NAME = 'gulp-lodash-builder';
 
 function gulpLodashRequire(options) {
-  var options = options ? options : {target: './lodash.custom.js', settings: {}};
+  var options = options ? options : {target: './lodash.custom.js', settings: {}, build: 'compat'};
   var dependiencies = [];
   var search = /_\.(\w*)/g;
 
@@ -52,6 +52,7 @@ function gulpLodashRequire(options) {
     childProcess.execFile(builder, [
         '-d',
         '-c',
+        options.build,
         'include=' + dependiencies.join(', '),
         'settings=' + JSON.stringify(options.settings)
       ],

--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ var pkg = require('lodash-cli/package.json'),
 var PLUGIN_NAME = 'gulp-lodash-builder';
 
 function gulpLodashRequire(options) {
-  var options = options ? {};
-  options.target = options.target ? './lodash.custom.js';
-  options.settings = options.settings ? {};
-  options.build = options.build ? 'compat';
+  var options = options ? options : {};
+  options.target = options.target ? options.target : './lodash.custom.js';
+  options.settings = options.settings ? options.settings : {};
+  options.build = options.build ? options.build : 'compat';
 
   var dependiencies = [];
   var search = /_\.(\w*)/g;


### PR DESCRIPTION
This lets you customize which build type to use: `compat`, `modern`, etc.

This change also fixes issues when passing an `options` object without specifying each needed key.

Adds documentation for `options`.
